### PR TITLE
New shortcodes, 'info' and 'wip'

### DIFF
--- a/layouts/shortcodes/info.html
+++ b/layouts/shortcodes/info.html
@@ -1,0 +1,5 @@
+<div class="ui blue message">
+  <div class="content">
+    <p>{{ .Inner | markdownify }}</p>
+  </div>
+</div>

--- a/layouts/shortcodes/wip.html
+++ b/layouts/shortcodes/wip.html
@@ -1,0 +1,11 @@
+<div class="ui yellow message">
+  <div class="content">
+    <div class="header">
+      Work in Progress
+    </div>
+    <p>
+      This section is incomplete. Sorry! Give us some time to continue expanding the documentation,
+      and we'll have great content for you here.
+    </p>
+  </div>
+</div>


### PR DESCRIPTION
This PR introduces two new shortcodes for the upcoming expansion of the protocol documentation: `info` (a wide blue box for clarifications) and `wip` (a placeholder for content).