### PR TITLE
Change h6 size and .goat margin

### DIFF
--- a/assets/_markdown.scss
+++ b/assets/_markdown.scss
@@ -53,7 +53,12 @@
   }
 
   h6 {
-    font-size: 0.75em;
+    margin-top: 28px;
+    font-size: 1.15em;
+  }
+
+  .goat {
+    margin-bottom: 20px;
   }
 
   b,


### PR DESCRIPTION
Required to see the new contributor/runtime section without suffering (I used these to format special sections, and the `goat` diagrams needed space).

As far as I can tell, the `h6` tag and the diagrams are not used elsewhere.